### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,12 @@ updates:
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 3
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 3

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,3 +7,8 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
# Harden GitHub Actions workflows

**Refs:** PSEC-923

This PR applies two small, low-risk security hardening changes to the
repository's GitHub Actions workflows. Both are behavior-preserving for CI.

## Changes

- **Disable credential persistence on checkout** (`go-test.yaml`): set
  `persist-credentials: false` on the `actions/checkout` step, so the
  `GITHUB_TOKEN` is not left in the local git config where a later step could
  read or leak it.

- **Dependabot cooldown + zizmor config** (`dependabot.yml`, `.github/zizmor.yml`,
  `zizmor.yaml`): add a 3-day `cooldown` to the Dependabot ecosystems to reduce
  churn from same-day releases; disable the cosmetic `anonymous-definition` and
  `concurrency-limits` pedantic rules (campaign-consistent); and add
  `.github/dependabot.yml` + `.github/zizmor.yml` to the Zizmor workflow's
  trigger paths so they are re-linted when changed. Existing config is
  preserved.
